### PR TITLE
Fix pasting (again...)

### DIFF
--- a/fix-twitter.js
+++ b/fix-twitter.js
@@ -1,6 +1,6 @@
 // simply tell the javascript of the page that we're on an up-to-date version
 window.eval(`
 Object.defineProperty(navigator, 'userAgent', {
-  get: ()=>"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0"
+  get: ()=>"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36"
 })
 `) // firefox is weird, if we didn't do this it'd define useragent on a shadow navigator that doesn't show to the website


### PR DESCRIPTION
For some reason, on Windows, Twitter uses a workaround for Firefox that no longer is applicable. This causes it to ignore clipboardData, meaning it will not paste the image.

This simply updates the fix-twitter.js user agent to say it's Chrome, because then Twitter will use the proper method for getting clipboard data.

And people say the age of user agent sniffing is dead...